### PR TITLE
Get service by tags

### DIFF
--- a/consul-service-wrapper.d.ts
+++ b/consul-service-wrapper.d.ts
@@ -30,7 +30,7 @@ declare namespace SSConsul {
     /**
      * Register a service with consul
      * Example:
-     * 
+     *
      * {
      *  name: 'redis,
      *  port: 6379,
@@ -51,10 +51,21 @@ declare namespace SSConsul {
      * Fetches a service by tag, if more than one is available
      * a random one is returned
      * Example:
-     * 
+     *
      * consul.getServiceBytag('redis', 'stable')
      */
     getServiceByTag(serviceName: string, tag: string): Promise<object>
+
+    /**
+     * Fetches a service(s) associated with a set of tags. If the tags
+     * do not match all of the tags a service is associated with, then it
+     * will not be returned.
+     * Example:
+     *
+     * // returns any nodes that match the tags: stable && testing.
+     * consul.getServiceByTag('redis', ['stable', 'testing'])
+     */
+    getServiceByTag(serviceName: string, tags: Array<string>) : Promise<object>
 
     /**
      * Returns a uri for a service

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,17 +117,37 @@ class ConsulService {
           return resolve(null)
         }
 
-        const services = result.filter(service => {
-          let found = false
+        let services = []
 
-          service.ServiceTags.forEach(serviceTag => {
-            if (serviceTag === tag) {
-              found = true
-            }
+        // match a single tag
+        if (typeof tag === 'string') {
+          services = result.filter(service => {
+            let found = false
+
+            service.ServiceTags.forEach(serviceTag => {
+              if (serviceTag === tag) {
+                found = true
+              }
+            })
+
+            return found
           })
+        // match a set of tags
+        } else if (tag instanceof Array) {
+          services = result.filter(service => {
+            if (service.ServiceTags.length !== tag.length) {
+              return false
+            }
 
-          return found
-        })
+            for (let requiredTag of service.ServiceTags) {
+              if (tag.indexOf(requiredTag) === -1) {
+                return false
+              }
+            }
+
+            return true
+          })
+        }
 
         if (services.length > 1) {
           return resolve(services[Math.floor(Math.random() * services.length)])

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,6 +147,8 @@ class ConsulService {
 
             return true
           })
+        } else {
+          throw new Error('Tag must be of type Array or String.')
         }
 
         if (services.length > 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ class ConsulService {
             return true
           })
         } else {
-          throw new Error('Tag must be of type Array or String.')
+          throw new TypeError('Tag must be of type Array or String.')
         }
 
         if (services.length > 1) {

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -322,6 +322,52 @@ describe('src/index.js', () => {
             expect(service).to.deep.equal(services[0])
           })
       })
+
+      describe('when passing in an array of tags', () => {
+        const consulService = new ConsulService()
+        const services = [
+          {
+            Node: 'MBP',
+            Address: '127.0.0.1',
+            TaggedAddresses: { lan: '127.0.0.1', wan: '127.0.0.1' },
+            ServiceID: 'test-service',
+            ServiceName: 'test-service',
+            ServiceTags: [ 'redis', 'testing' ],
+            ServiceAddress: '',
+            ServicePort: 8080,
+            ServiceEnableTagOverride: false,
+            CreateIndex: 1440,
+            ModifyIndex: 1452
+          }
+        ]
+        consulService.consul.catalog.service.nodes = (service, callback) => {
+          callback(null, services)
+        }
+
+        it('should return services that are associated with a set of tags', () => {
+          return consulService
+            .getServiceByTag('test-service', ['redis', 'testing'])
+            .then(service => {
+              expect(service).to.deep.equal(services[0])
+            })
+        })
+
+        it('should return null if not all tags match a service\'s set of tags', () => {
+          return consulService
+            .getServiceByTag('test-service', ['testing'])
+            .then(service => {
+              expect(service).to.deep.equal(null)
+            })
+        })
+
+        it('should return null if tags is an empty array', () => {
+          return consulService
+            .getServiceByTag('test-service', [])
+            .then(service => {
+              expect(service).to.deep.equal(null)
+            })
+        })
+      })
     })
 
     describe('formatUri', () => {


### PR DESCRIPTION
**changes**
- You can now fetch nodes by an array of tags. 
- All of a node's tags must be present in the tags you use to fetch a node, otherwise null is returned