### PR TITLE
Fixing formatUri to use 'ServiceAddress' and not 'Address'.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,8 +175,8 @@ class ConsulService {
       throw formatUriError('"service" is required')
     }
 
-    const { Address, ServicePort } = service
-    return util.format('%s:%d', Address, ServicePort)
+    const { ServiceAddress, ServicePort } = service
+    return util.format('%s:%d', ServiceAddress, ServicePort)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consul-service-wrapper",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Easily create a service and register it with Consul in node.",
   "main": "index.js",
   "scripts": {

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -373,7 +373,7 @@ describe('src/index.js', () => {
     describe('formatUri', () => {
       it('Should return a formatted URI when a service is passed in', () => {
         const consul = new ConsulService()
-        const uri = consul.formatUri({ Address: '127.0.0.1', ServicePort: 80 })
+        const uri = consul.formatUri({ ServiceAddress: '127.0.0.1', ServicePort: 80 })
         expect(uri).to.equal('127.0.0.1:80')
       })
 


### PR DESCRIPTION
Fixing `formatUri` method to use the `ServiceAddress` and not `Address` based on https://www.consul.io/api/catalog.html#serviceaddress.

This is to resolve issue #9.
