### PR TITLE
'formatUri' should fallback to use 'Address' if 'ServiceAddress' isn't defined.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,7 @@ class ConsulService {
 
     const { ServiceAddress, Address, ServicePort } = service
 
-    return ServiceAddress ? `${ServiceAddress}:${ServicePort}` : `${Address}:${ServicePort}`
+    return `${ServiceAddress || Address}:${ServicePort}`
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const Consul = require('consul')
-const util = require('util')
 
 const invalidServiceConfig = require('./errors').invalidServiceConfig
 const getServiceError = require('./errors').getServiceError
@@ -175,8 +174,9 @@ class ConsulService {
       throw formatUriError('"service" is required')
     }
 
-    const { ServiceAddress, ServicePort } = service
-    return util.format('%s:%d', ServiceAddress, ServicePort)
+    const { ServiceAddress, Address, ServicePort } = service
+
+    return ServiceAddress ? `${ServiceAddress}:${ServicePort}` : `${Address}:${ServicePort}`
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consul-service-wrapper",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Easily create a service and register it with Consul in node.",
   "main": "index.js",
   "scripts": {

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -373,8 +373,18 @@ describe('src/index.js', () => {
     describe('formatUri', () => {
       it('Should return a formatted URI when a service is passed in', () => {
         const consul = new ConsulService()
-        const uri = consul.formatUri({ ServiceAddress: '127.0.0.1', ServicePort: 80 })
+        const uri = consul.formatUri({
+          ServiceAddress: '127.0.0.1',
+          Address: '127.0.1.1',
+          ServicePort: 80
+        })
         expect(uri).to.equal('127.0.0.1:80')
+      })
+
+      it('Should return "Address" when "ServiceAddress" isn\'t defined', () => {
+        const consul = new ConsulService()
+        const uri = consul.formatUri({ Address: '127.0.1.1', ServicePort: 80 })
+        expect(uri).to.equal('127.0.1.1:80')
       })
 
       it('Should thorw if no service is defined', () => {


### PR DESCRIPTION
Adding fallback to use `Address` when `ServiceAddress` isn't defined.

From @nicolaslt
> Address is the IP address of the Consul node on which the service is registered.
> ServiceAddress is the IP address of the service host — if empty, node address should be used.